### PR TITLE
Extra sanity test runner: allow to ignore prefixes

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -18,7 +18,7 @@ Once ansible-test supports custom code-smell plugins, this tool will be deprecat
 
 The runner looks for tests in `tests/sanity/extra/`. Every test must consist of a JSON config file `<test>.json` and a Python script `<test>.py`. The executable does not need to be executable. It will be invoked as `python<version> tests/sanity/extra/<test>.py <target>...`, where `<target>...` is a list of files that the test is supposed to check. This list will be compiled according to the configuration file.
 
-Besides very similar target selection configurations to ansible-test, it allows to specify `"python": "<version>"` for the Python version to use, and `"requirements": [...]` to install additional Python requirements needed for this test.
+Besides very similar target selection configurations to ansible-test, it allows to specify `"python": "<version>"` for the Python version to use, and `"requirements": [...]` to install additional Python requirements needed for this test. It is also possible to ignore certain prefixes with `exclude_prefixes`.
 
 ### Example usage: lint changelog fragments
 
@@ -31,6 +31,9 @@ This example runs [`ansibulled-changelog lint`](https://github.com/ansible-commu
     "output": "path-line-column-message",
     "prefixes": [
         "changelogs/fragments/"
+    ],
+    "exclude_prefixes": [
+        "changelogs/fragments/."
     ],
     "requirements": [
         "git+git://github.com/ansible-community/ansibulled.git@pip-installable#egg=ansibulled"

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -125,6 +125,7 @@ class Test:
 
         self.extensions = data.get('extensions')
         self.prefixes = data.get('prefixes')
+        self.exclude_prefixes = data.get('exclude_prefixes')
         self.files = data.get('files')
         self.text = data.get('text')
         self.ignore_self = data.get('ignore_self')
@@ -151,6 +152,9 @@ class Test:
 
         if self.prefixes:
             targets = [target for target in targets if any(target.startswith(pre) for pre in self.prefixes)]
+
+        if self.exclude_prefixes:
+            targets = [target for target in targets if all(not target.startswith(pre) for pre in self.exclude_prefixes)]
 
         if self.files:
             targets = [target for target in targets if os.path.basename(target) in self.files]


### PR DESCRIPTION
##### SUMMARY
Needed to avoid `changelogs/fragments/.keep` to be linted.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tools/runner.py
