### PR TITLE
antsibull-changelog moved to its own repo

### DIFF
--- a/tests/sanity/extra/changelog.json
+++ b/tests/sanity/extra/changelog.json
@@ -8,6 +8,6 @@
         "changelogs/fragments/."
     ],
     "requirements": [
-        "antsibull"
+        "antsibull-changelog"
     ]
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -22,7 +22,7 @@ Besides very similar target selection configurations to ansible-test, it allows 
 
 ### Example usage: lint changelog fragments
 
-This example runs [`antsibull-changelog lint`](https://github.com/ansible-community/antsibull/blob/master/docs/changelogs.rst#validating-changelog-fragments) to lint all changelog fragments. The wrapper script uses Python 3.7, and installs [antsibull](https://pypi.org/project/antsibull/) before running.
+This example runs [`antsibull-changelog lint`](https://github.com/ansible-community/antsibull-changelog/blob/master/docs/changelogs.rst#validating-changelog-fragments) to lint all changelog fragments. The wrapper script uses Python 3.7, and installs [antsibull-changelog](https://pypi.org/project/antsibull-changelog/) before running.
 
 `tests/sanity/extra/changelog.json`:
 ```.json
@@ -36,7 +36,7 @@ This example runs [`antsibull-changelog lint`](https://github.com/ansible-commun
         "changelogs/fragments/."
     ],
     "requirements": [
-        "git+git://github.com/ansible-community/antsibull.git@pip-installable#egg=antsibull"
+        "antsibull-changelog"
     ]
 }
 ```


### PR DESCRIPTION
##### SUMMARY
antsibull-changelog moved from https://github.com/ansible-community/antsibull/ to https://github.com/ansible-community/antsibull-changelog/.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
tools/README.md
