### PR TITLE
Prepare for devel version bump

### DIFF
--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,2 @@
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY
Copies tests/sanity/ignore-2.10.txt to tests/sanity/ignore-2.11.txt. Will be necessary once `stable-2.10` is branched in ansible/ansible, and `devel`'s version is bumped to 2.11.0.dev0 (which probably happens today).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
