### PR TITLE
Allow to apply predicate to content for fetch_url and open_url frameworks

### DIFF
--- a/changelogs/fragments/open_url-framework.yml
+++ b/changelogs/fragments/open_url-framework.yml
@@ -1,6 +1,6 @@
 minor_changes:
 - Added a framework for testing plugins using ``open_url`` from ``ansible.module_utils.urls`` (https://github.com/ansible-collections/community.internal_test_tools/pull/24).
-- The ``fetch_url`` testing framework now allows to match the provided content (https://github.com/ansible-collections/community.internal_test_tools/pull/24).
+- The ``fetch_url`` testing framework now allows to match the provided content (https://github.com/ansible-collections/community.internal_test_tools/pull/31).
 
 bugfixes:
 - Fix header test for ``fetch_url`` testing framework (https://github.com/ansible-collections/community.internal_test_tools/pull/24).

--- a/tests/unit/plugins/lookup/test_open_url_test_lookup.py
+++ b/tests/unit/plugins/lookup/test_open_url_test_lookup.py
@@ -55,6 +55,7 @@ class TestLookupModule(TestCase):
             .result_json({'1': 2})
             .return_header('content-type', 'application/json')
             .expect_content('name=foo&email=name@example.com'.encode('utf-8'))
+            .expect_content_predicate(lambda content: True)
             .expect_header('foo', 'bar')
             .expect_header_unset('baz'),
             OpenUrlCall('POST', 500)

--- a/tests/unit/plugins/modules/test_fetch_url_test_module.py
+++ b/tests/unit/plugins/modules/test_fetch_url_test_module.py
@@ -96,6 +96,7 @@ class TestFetchURLTestModule(BaseTestModule):
             FetchUrlCall('GET', 400)
             .result_error('meh', b'1234')
             .expect_content(b'\x00\x01\x02')
+            .expect_content_predicate(lambda content: True)
             .expect_header('foo', 'bar')
             .expect_header_unset('baz')
             .expect_url('http://example.com/'),

--- a/tests/unit/utils/fetch_url_module_framework.py
+++ b/tests/unit/utils/fetch_url_module_framework.py
@@ -68,6 +68,7 @@ __metaclass__ = type
 
 
 import json
+import traceback
 
 import pytest
 
@@ -278,7 +279,9 @@ class _FetchUrlProxy:
             try:
                 assert call.expected_content_predicate(data), 'Predicate has falsy result'
             except Exception as e:
-                raise AssertionError('Content does not match predicate for fetch_url call') from e
+                raise AssertionError(
+                    'Content does not match predicate for fetch_url call: {0}\n\n{1}'.format(
+                        e, traceback.format_exc()))
         if call.form_parse:
             self._validate_form(call, data)
 

--- a/tests/unit/utils/fetch_url_module_framework.py
+++ b/tests/unit/utils/fetch_url_module_framework.py
@@ -104,6 +104,7 @@ class FetchUrlCall:
         self.expected_url = None
         self.expected_headers = {}
         self.expected_content = None
+        self.expected_content_predicate = None
         self.form_parse = False
         self.form_present = set()
         self.form_values = {}
@@ -173,6 +174,13 @@ class FetchUrlCall:
         Builder method to set an expected content for a ``fetch_url()`` call.
         '''
         self.expected_content = content
+        return self
+
+    def expect_content_predicate(self, content_predicate):
+        '''
+        Builder method to set an expected content predicate for a ``fetch_url()`` call.
+        '''
+        self.expected_content_predicate = content_predicate
         return self
 
     def expect_form_present(self, key):
@@ -266,6 +274,11 @@ class _FetchUrlProxy:
             self._validate_headers(call, headers)
         if call.expected_content is not None:
             assert data == call.expected_content, 'Expected content does not match for fetch_url call'
+        if call.expected_content_predicate:
+            try:
+                assert call.expected_content_predicate(data), 'Predicate has falsy result'
+            except Exception as e:
+                raise AssertionError('Content does not match predicate for fetch_url call') from e
         if call.form_parse:
             self._validate_form(call, data)
 

--- a/tests/unit/utils/open_url_framework.py
+++ b/tests/unit/utils/open_url_framework.py
@@ -59,6 +59,7 @@ __metaclass__ = type
 
 
 import json
+import traceback
 
 import pytest
 
@@ -282,7 +283,9 @@ class OpenUrlProxy:
             try:
                 assert call.expected_content_predicate(data), 'Predicate has falsy result'
             except Exception as e:
-                raise AssertionError('Content does not match predicate for open_url call') from e
+                raise AssertionError(
+                    'Content does not match predicate for open_url call: {0}\n\n{1}'.format(
+                        e, traceback.format_exc()))
         if call.form_parse:
             self._validate_form(call, data)
 

--- a/tests/unit/utils/open_url_framework.py
+++ b/tests/unit/utils/open_url_framework.py
@@ -93,6 +93,7 @@ class OpenUrlCall:
         self.expected_url = None
         self.expected_headers = {}
         self.expected_content = None
+        self.expected_content_predicate = None
         self.form_parse = False
         self.form_present = set()
         self.form_values = {}
@@ -173,6 +174,13 @@ class OpenUrlCall:
         Builder method to set an expected content for a ``open_url()`` call.
         '''
         self.expected_content = content
+        return self
+
+    def expect_content_predicate(self, content_predicate):
+        '''
+        Builder method to set an expected content predicate for a ``open_url()`` call.
+        '''
+        self.expected_content_predicate = content_predicate
         return self
 
     def expect_form_present(self, key):
@@ -270,6 +278,11 @@ class OpenUrlProxy:
             self._validate_headers(call, headers)
         if call.expected_content is not None:
             assert data == call.expected_content, 'Expected content does not match for open_url call'
+        if call.expected_content_predicate:
+            try:
+                assert call.expected_content_predicate(data), 'Predicate has falsy result'
+            except Exception as e:
+                raise AssertionError('Content does not match predicate for open_url call') from e
         if call.form_parse:
             self._validate_form(call, data)
 


### PR DESCRIPTION
It seems this was already announced in the changelog fragment (https://github.com/ansible-collections/community.internal_test_tools/blob/main/changelogs/fragments/open_url-framework.yml#L3), but apparently got lost during implementation in that PR.