### PR TITLE
open_url/fetch_url frameworks: allow to handle query and fragment parameters for URLs

### DIFF
--- a/changelogs/fragments/33-query-fragment.yml
+++ b/changelogs/fragments/33-query-fragment.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- "fetch_url and open_url testing frameworks - allow to compare URLs without query and/or fragment (https://github.com/ansible-collections/community.internal_test_tools/pull/33)."
+- "fetch_url and open_url testing frameworks - allow to check query parameters of URLs (https://github.com/ansible-collections/community.internal_test_tools/pull/33)."
+bugfixes:
+- "fetch_url testing framework - return ``url`` as part of ``info`` (https://github.com/ansible-collections/community.internal_test_tools/pull/33)."

--- a/tests/unit/utils/fetch_url_module_framework.py
+++ b/tests/unit/utils/fetch_url_module_framework.py
@@ -295,20 +295,22 @@ class _FetchUrlProxy:
         self.index += 1
 
         # Validate call
-        assert method == call.method, 'Expected method does not match for fetch_url call'
+        assert method == call.method, 'Expected method does not match for fetch_url call: {0!r} instead of {1!r}'.format(
+            method, call.method)
         if call.expected_url is not None:
             reduced_url = _reduce_url(
                 url,
                 remove_query=call.expected_url_without_query,
                 remove_fragment=call.expected_url_without_fragment)
             assert reduced_url == call.expected_url, \
-                'Exepected URL does not match for fetch_url call'
+                'Expected URL does not match for fetch_url call: {0!r} instead of {1!r}'.format(reduced_url, call.expected_url)
         if call.expected_query:
             self._validate_query(call, url)
         if call.expected_headers:
             self._validate_headers(call, headers)
         if call.expected_content is not None:
-            assert data == call.expected_content, 'Expected content does not match for fetch_url call'
+            assert data == call.expected_content, 'Expected content does not match for fetch_url call: {0!r} instead of {1!r}'.format(
+                data, call.expected_content)
         if call.expected_content_predicate:
             try:
                 assert call.expected_content_predicate(data), 'Predicate has falsy result'

--- a/tests/unit/utils/open_url_framework.py
+++ b/tests/unit/utils/open_url_framework.py
@@ -328,20 +328,22 @@ class OpenUrlProxy:
         self.index += 1
 
         # Validate call
-        assert method == call.method
+        assert method == call.method, 'Expected method does not match for fetch_url call: {0!r} instead of {1!r}'.format(
+            method, call.method)
         if call.expected_url is not None:
             reduced_url = _reduce_url(
                 url,
                 remove_query=call.expected_url_without_query,
                 remove_fragment=call.expected_url_without_fragment)
             assert reduced_url == call.expected_url, \
-                'Exepected URL does not match for open_url call'
+                'Exepected URL does not match for open_url call: {0!r} instead of {1!r}'.format(reduced_url, call.expected_url)
         if call.expected_query:
             self._validate_query(call, url)
         if call.expected_headers:
             self._validate_headers(call, headers)
         if call.expected_content is not None:
-            assert data == call.expected_content, 'Expected content does not match for open_url call'
+            assert data == call.expected_content, 'Expected content does not match for open_url call: {0!r} instead of {1!r}'.format(
+                data, call.expected_content)
         if call.expected_content_predicate:
             try:
                 assert call.expected_content_predicate(data), 'Predicate has falsy result'

--- a/tests/unit/utils/open_url_framework.py
+++ b/tests/unit/utils/open_url_framework.py
@@ -81,7 +81,7 @@ def _extract_query(url):
         query = url[query_index + 1:fragment_index]
     else:
         query = url[query_index + 1:]
-    return parse_qs(query)
+    return parse_qs(query, keep_blank_values=True)
 
 
 def _reduce_url(url, remove_query=False, remove_fragment=False):


### PR DESCRIPTION
Needed for ansible-collections/community.dns#4.