### PR TITLE
Bump runner default Python version from 3.7 to 3.8

### DIFF
--- a/changelogs/fragments/49-runner-python.yml
+++ b/changelogs/fragments/49-runner-python.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "extra sanity test runner - bump default Python version from 3.7 to 3.8 (https://github.com/ansible-collections/community.internal_test_tools/pull/49)."

--- a/tests/sanity/extra/changelog.json
+++ b/tests/sanity/extra/changelog.json
@@ -1,5 +1,4 @@
 {
-    "python": "3.7",
     "output": "path-line-column-message",
     "prefixes": [
         "changelogs/fragments/"

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -17,7 +17,7 @@ import sys
 
 
 SEPARATOR = '=' * 74
-DEFAULT_PYTHON = '3.7'
+DEFAULT_PYTHON = '3.8'
 
 COLORS = {
     'emph': 1,


### PR DESCRIPTION
##### SUMMARY
Especially since ansible-core requires 3.8 by now, it's better to switch to it.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
extra sanity test runner
