### PR TITLE
Ignore atime for diff detection

### DIFF
--- a/changelogs/fragments/54-files_diff-atime.yml
+++ b/changelogs/fragments/54-files_diff-atime.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "files_collect, files_diff - ignore ``atime`` since that does not indicate that a file was modified (https://github.com/ansible-collections/community.internal_test_tools/pull/54)."

--- a/plugins/module_utils/state.py
+++ b/plugins/module_utils/state.py
@@ -24,7 +24,7 @@ def extract_stat(stat):
         'uid': stat.st_uid,
         'gid': stat.st_gid,
         'size': stat.st_size,
-        'atime': stat.st_atime,
+        # 'atime': stat.st_atime,  -- we care about modifications, not about access
         'mtime': stat.st_mtime,
         'ctime': stat.st_ctime,
         'blocks': getattr(stat, 'st_blocks', None),


### PR DESCRIPTION
##### SUMMARY
atime indicates when the file was last accessed. We should not use that for change detection.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
files_collect
files_diff
