### PR TITLE
Extra sanity test runner: improve how to run pip

### DIFF
--- a/changelogs/fragments/104-runner-pip.yml
+++ b/changelogs/fragments/104-runner-pip.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "extra sanity test runner - run pip via Python instead of running it directly; also set ``PIP_BREAK_SYSTEM_PACKAGES=1`` in the environment (https://github.com/ansible-collections/community.internal_test_tools/pull/104)."

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -297,7 +297,9 @@ def setup(tests, use_color=True):
         print(colorize('Installing requirements', 'emph', use_color))
     for python_version, reqs in sorted(requirements.items()):
         command = [
-            'pip{0}'.format(python_version),
+            'python{0}'.format(python_version),
+            '-m',
+            'pip'
             'install',
             '--disable-pip-version-check'
         ] + reqs

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -303,8 +303,11 @@ def setup(tests, use_color=True):
             'install',
             '--disable-pip-version-check'
         ] + reqs
+        env = os.environ.copy()
+        # Allow to break system packages (PEP-668). Since we have an isolated environment, this shouldn't be a problem
+        env['PIP_BREAK_SYSTEM_PACKAGES'] = '1'
         print(colorize('Running {0}'.format(join_command(command)), 'emph', use_color))
-        process_result = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process_result = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
         stdout, stderr = process_result.communicate()
         if stdout:
             for line in stdout.decode('utf-8').splitlines():

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -299,7 +299,7 @@ def setup(tests, use_color=True):
         command = [
             'python{0}'.format(python_version),
             '-m',
-            'pip'
+            'pip',
             'install',
             '--disable-pip-version-check'
         ] + reqs


### PR DESCRIPTION
##### SUMMARY
Run pip as `python -m pip`. Also pass `PIP_BREAK_SYSTEM_PACKAGES=1` in the environment.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
extra sanity test runner
