### PR TITLE
Remove ignore.txt entries for ansible-core devel branch

### DIFF
--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,2 +1,0 @@
-plugins/lookup/_open_url_test_lookup.py validate-modules:collections-no-underscore-on-deprecation  # https://github.com/ansible/ansible/pull/82575
-plugins/modules/_fetch_url_test_module.py validate-modules:collections-no-underscore-on-deprecation  # https://github.com/ansible/ansible/pull/82575

--- a/tests/sanity/ignore-2.17.txt.license
+++ b/tests/sanity/ignore-2.17.txt.license
@@ -1,3 +1,0 @@
-GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
-SPDX-License-Identifier: GPL-3.0-or-later
-SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/pull/82575 has been merged, so they are no longer necessary.

Since that PR won't get backported only ignore-2.17.txt needs to be cleaned up.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
sanity tests
