### PR TITLE
tests: replace mock import with unittest.mock

### DIFF
--- a/changelogs/fragments/130-compat-mock.yaml
+++ b/changelogs/fragments/130-compat-mock.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - "tests - use the ``tests.unit.compat.mock`` module everywhere so that
+    ``unittest.mock`` is used instead of ``mock`` on Python 3
+    (https://github.com/ansible-collections/community.internal_test_tools/pull/130)."

--- a/changelogs/fragments/130-compat-mock.yaml
+++ b/changelogs/fragments/130-compat-mock.yaml
@@ -1,5 +1,5 @@
 ---
 minor_changes:
-  - "tests - use the ``tests.unit.compat.mock`` module everywhere so that
+  - "fetch_url and open_url unit test frameworks - use the ``tests.unit.compat.mock`` module everywhere so that
     ``unittest.mock`` is used instead of ``mock`` on Python 3
     (https://github.com/ansible-collections/community.internal_test_tools/pull/130)."

--- a/tests/unit/utils/fetch_url_module_framework.py
+++ b/tests/unit/utils/fetch_url_module_framework.py
@@ -69,13 +69,12 @@ __metaclass__ = type
 
 import pytest
 
-from mock import MagicMock
-
 import ansible.module_utils.basic  # noqa: F401, pylint: disable=unused-import
 import ansible.module_utils.urls  # noqa: F401, pylint: disable=unused-import
 
 from ansible.module_utils.six import PY2
 
+from ansible_collections.community.internal_test_tools.tests.unit.compat.mock import MagicMock
 from ansible_collections.community.internal_test_tools.tests.unit.plugins.modules.utils import set_module_args
 
 from ._utils import (

--- a/tests/unit/utils/open_url_framework.py
+++ b/tests/unit/utils/open_url_framework.py
@@ -59,14 +59,13 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-from mock import MagicMock
-
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 
 from ._utils import (
     CallBase as _CallBase,
     validate_call as _validate_call,
 )
+from ..compat.mock import MagicMock
 
 
 class OpenUrlCall(_CallBase):


### PR DESCRIPTION
##### SUMMARY

tests: replace mock import with unittest.mock

This avoids pulling in an extra dependency on Python 3.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
tests

##### ADDITIONAL INFORMATION

No changelog entry, as this is an internal change.