### PR TITLE
Bump Python version and fallback container image for extra sanity test runner

### DIFF
--- a/changelogs/fragments/137-runner.yml
+++ b/changelogs/fragments/137-runner.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "extra sanity tests runner - update fallback image name and use Python 3.13 inside the container (https://github.com/ansible-collections/community.internal_test_tools/pull/137)."
+  - "extra sanity tests runner - add ``--break-system-packages`` to ``pip`` invocations (https://github.com/ansible-collections/community.internal_test_tools/pull/137)."
+  - "extra sanity tests runner - bump default Python version used for tests to 3.13 (https://github.com/ansible-collections/community.internal_test_tools/pull/137)."

--- a/tools/run.py
+++ b/tools/run.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 
 
-DEFAULT_DOCKER_CONTAINER_FALLBACK = 'quay.io/ansible/default-test-container:5.4.0'
+DEFAULT_DOCKER_CONTAINER_FALLBACK = 'quay.io/ansible/default-test-container:11.3.0'
 
 
 COLORS = {
@@ -252,7 +252,7 @@ def main():
         run(['docker', 'cp', root, '{0}:{1}'.format(container_name, os.path.dirname(root))], use_color=use_color)
         # run(['docker', 'exec', container_name, '/bin/sh', '-c', 'ls -lah ; pwd'])
         command = ['docker', 'exec', container_name]
-        command.extend(['python3.10', os.path.relpath(os.path.join(my_dir, 'runner.py'), cwd)])
+        command.extend(['python3.13', os.path.relpath(os.path.join(my_dir, 'runner.py'), cwd)])
         command.extend(['--cleanup', '--install-requirements', '--output', output_filename])
         if use_color:
             command.extend(['--color'])

--- a/tools/runner.py
+++ b/tools/runner.py
@@ -18,7 +18,7 @@ import sys
 
 
 SEPARATOR = '=' * 74
-DEFAULT_PYTHON = '3.10'
+DEFAULT_PYTHON = '3.13'
 
 COLORS = {
     'emph': 1,
@@ -301,7 +301,8 @@ def setup(tests, use_color=True):
             '-m',
             'pip',
             'install',
-            '--disable-pip-version-check'
+            '--disable-pip-version-check',
+            '--break-system-packages',
         ] + reqs
         env = os.environ.copy()
         # Allow to break system packages (PEP-668). Since we have an isolated environment, this shouldn't be a problem


### PR DESCRIPTION
##### SUMMARY
* Use Python 3.13 to run the runner itself.
* Bump default Python version used for tests to 3.13.
* Add `--break-system-packages` to pip calls.
* Bump fallback container image name.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
extra sanity test runner
