### PR TITLE
Add tools to mark values as trusted, untrusted, and to check whether a value is trusted

### DIFF
--- a/changelogs/fragments/146-trust.yml
+++ b/changelogs/fragments/146-trust.yml
@@ -1,0 +1,15 @@
+minor_changes:
+  - >-
+    Provide helper utility ``ansible_collections.community.internal_test_tools.tests.unit.utils.trust`` for tests that
+    need to handle both ansible-core versions with and without Data Tagging:
+
+
+    * The helper functions ``make_trusted()`` and ``make_untrusted()`` mark a value as trusted respectively untrusted (with Data Tagging), or as safe or unsafe (before Data Tagging).
+
+    * The function ``is_trusted()`` allows to check with all versions of ansible-core whether a value is trusted (not unsafe) or not trusted (unsafe).
+
+    * The constant ``SUPPORTS_DATA_TAGGING`` allows to decide whether ansible-core supports Data Tagging or not.
+
+
+    Note that Data Tagging support right now is not implemented and will be added later
+    (https://github.com/ansible-collections/community.internal_test_tools/pull/146)

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -16,6 +16,9 @@ from ansible.module_utils.common.text.converters import to_bytes
 
 @_contextlib.contextmanager
 def set_module_args(args):
+    """
+    Context manager that sets module arguments for AnsibleModule
+    """
     if '_ansible_remote_tmp' not in args:
         args['_ansible_remote_tmp'] = '/tmp'
     if '_ansible_keep_remote_files' not in args:
@@ -27,25 +30,43 @@ def set_module_args(args):
 
 
 class AnsibleExitJson(Exception):
+    """
+    Exception raised by exit_json() to signal that the module exited successful.
+    """
     pass
 
 
 class AnsibleFailJson(Exception):
+    """
+    Exception raised by fail_json() to signal that the module failed.
+    """
     pass
 
 
 def exit_json(*args, **kwargs):
+    """
+    Mock replacement for AnsibleModule.exit_json() that raises AnsibleExitJson.
+    """
     if 'changed' not in kwargs:
         kwargs['changed'] = False
     raise AnsibleExitJson(kwargs)
 
 
 def fail_json(*args, **kwargs):
+    """
+    Mock replacement for AnsibleModule.fail_json() that raises AnsibleFailJson.
+    """
     kwargs['failed'] = True
     raise AnsibleFailJson(kwargs)
 
 
 class ModuleTestCase(unittest.TestCase):
+    """
+    Provides some infrastructure for using unittest.TestCase.
+
+    Note that unittest.TestCase is not the recommended way of writing Ansible unit tests, but there
+    still are a lot of existing tests in this form.
+    """
 
     def setUp(self):
         self.mock_module = patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)

--- a/tests/unit/utils/test_trust.py
+++ b/tests/unit/utils/test_trust.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 Ansible
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from .trust import (
+    make_trusted,
+    make_untrusted,
+    is_trusted,
+)
+
+
+def test_trust():
+    trusted = make_trusted("foo")
+    untrusted = make_untrusted("bar")
+    assert is_trusted(trusted)
+    assert not is_trusted(untrusted)

--- a/tests/unit/utils/trust.py
+++ b/tests/unit/utils/trust.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 Ansible
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.six import string_types as _string_types
+from ansible.utils.unsafe_proxy import AnsibleUnsafe as _AnsibleUnsafe
+from ansible.utils.unsafe_proxy import wrap_var as _make_unsafe
+
+
+# Whether ansible-core supports Data Tagging
+SUPPORTS_DATA_TAGGING = False
+
+
+def make_trusted(input):
+    """
+    Given a value, marks it as trusted (if possible).
+
+    This is a no-op for ansible-core versions without Data Tagging.
+    There, all strings not explicitly marked as unsafe are trusted.
+
+    Note that this does not work recursively on data structures.
+    """
+    return input
+
+
+def make_untrusted(input):
+    """
+    Given a value, marks it as untrusted.
+
+    This works both with and without Data Tagging.
+
+    Note that this does not work recursively on data structures.
+    """
+    if isinstance(input, _string_types):
+        return _make_unsafe(input)
+    return input
+
+
+def is_trusted(input):
+    """
+    Given a value, checks whether it is trusted or not.
+
+    This uses Data Tagging methods when ansible-core supports Data Tagging (not yet implemented),
+    and checks for AnsibleUnsafe for older ansible-core versions.
+    """
+    return not isinstance(input, _AnsibleUnsafe)


### PR DESCRIPTION
##### SUMMARY
This is right now 'only' for existing ansible-core versions, without support for Data Tagging. That will be added in #143 (to be rebased on top of this PR).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
test utils
