### PR TITLE
CI: Restrict stable-2.19 versions

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -65,5 +65,6 @@ include_devel = true
 "2.16" = ["3.7"]
 "2.17" = ["3.8"]
 "2.18" = ["3.9"]
+"2.19" = ["3.9"]
 
 [sessions.ansible_lint]


### PR DESCRIPTION
##### SUMMARY
stable-2.19 is now part of CI.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
